### PR TITLE
feat: theme toggle button

### DIFF
--- a/Frontend/src/components/navbar.tsx
+++ b/Frontend/src/components/navbar.tsx
@@ -2,6 +2,7 @@ import {Link} from "react-router-dom";
 import {useAuth} from "../features/auth/model/useAuth.ts";
 import {navigationItems} from "../app/routes.tsx";
 import React, {useEffect, useState} from "react";
+import ThemeToggle from "./themeToggle.tsx";
 
 function Navbar() {
     const {user, isAuthenticated, logout} = useAuth();
@@ -34,8 +35,6 @@ function Navbar() {
                 z-[100]
                 static
                 top-0
-                transition-colors
-                duration-200
             "
         >
             <div>
@@ -177,6 +176,8 @@ function Navbar() {
                         </li>
                     </>
                 )}
+
+                <ThemeToggle/>
             </ul>
         </nav>
     );

--- a/Frontend/src/components/themeToggle.tsx
+++ b/Frontend/src/components/themeToggle.tsx
@@ -1,0 +1,79 @@
+﻿import React, {useEffect, useState} from "react";
+
+const THEME_KEY = "theme";
+
+function getPreferredTheme() {
+    if (typeof window === "undefined") {
+        return "dark";
+    }
+
+    const stored = localStorage.getItem(THEME_KEY);
+
+    if (stored === "light" || stored === "dark") {
+        return stored;
+    }
+
+    return "dark";
+}
+
+function setThemeAttribute(theme: string) {
+    document.documentElement.setAttribute("data-theme", theme);
+}
+
+function ThemeToggle() {
+    const [theme, setTheme] = useState<string>("dark");
+
+    useEffect(() => {
+        const preferred = getPreferredTheme();
+        setTheme(preferred);
+        setThemeAttribute(preferred);
+    }, []);
+
+    useEffect(() => {
+        setThemeAttribute(theme);
+        localStorage.setItem(THEME_KEY, theme);
+    }, [theme]);
+
+    const toggleTheme = () => {
+        setTheme(theme === "dark" ? "light" : "dark");
+    };
+
+    return (
+        <button
+            onClick={toggleTheme}
+            className="
+                px-4 py-2
+                rounded-full
+                transition-colors
+                duration-200
+                flex items-center justify-center
+                w-12 h-12
+                relative
+            "
+            aria-label="Toggle theme"
+        >
+            <span
+                className="transition-transform duration-300"
+                style={{transform: theme === "dark" ? "rotate(-10deg) scale(1.1)" : "rotate(60deg) scale(1.1)"}}
+            >
+                {theme === "dark" ? (
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
+                         style={{color: 'var(--color-link)'}}
+                         class="bi bi-moon-fill" viewBox="0 0 16 16">
+                        <path
+                            d="M6 .278a.77.77 0 0 1 .08.858 7.2 7.2 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277q.792-.001 1.533-.16a.79.79 0 0 1 .81.316.73.73 0 0 1-.031.893A8.35 8.35 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.75.75 0 0 1 6 .278"/>
+                    </svg>
+                ) : (
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor"
+                         style={{color: 'var(--color-link)'}}
+                         class="bi bi-brightness-high" viewBox="0 0 16 16">
+                        <path
+                            d="M8 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6m0 1a4 4 0 1 0 0-8 4 4 0 0 0 0 8M8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0m0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13m8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5M3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8m10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.415a.5.5 0 1 1-.707-.708l1.414-1.414a.5.5 0 0 1 .707 0m-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0m9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707M4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .708"/>
+                    </svg>
+                )}
+            </span>
+        </button>
+    );
+}
+
+export default ThemeToggle;

--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -2,12 +2,27 @@
 
 @plugin "@tailwindcss/typography";
 
-:root {
+html[data-theme="light"] {
+    --color-primary: hsl(35, 30%, 96%);
+    --color-primary-hover: #f4f4f4;
+    --color-secondary: hsl(36, 16%, 94%);
+    --color-primary-text: #222;
+    --color-secondary-text: #bdbdbd;
+    color: var(--color-primary-text);
+    background-color: var(--color-primary);
+}
+
+html[data-theme="dark"] {
     --color-primary: #242424;
     --color-primary-hover: #373636;
     --color-secondary: #1a1a1a;
     --color-primary-text: #faf9f6;
     --color-secondary-text: #e7e5e1;
+    color: var(--color-primary-text);
+    background-color: var(--color-primary);
+}
+
+:root {
     --color-link: #2a99cc;
     --color-link-hover: #257ba2;
     --color-error: #bf2c2c;
@@ -17,9 +32,6 @@
     font-weight: 400;
 
     color-scheme: light dark;
-    color: var(--color-primary-text);
-    background-color: var(--color-primary);
-
     font-synthesis: none;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
@@ -45,17 +57,4 @@ body {
     margin: 0;
     min-width: 320px;
     min-height: 100vh;
-}
-
-@media (prefers-color-scheme: light) {
-    :root {
-        --color-primary: hsl(35, 30%, 96%);
-        --color-primary-hover: #f4f4f4;
-        --color-secondary: hsl(36, 16%, 94%);
-        --color-primary-text: #222;
-        --color-secondary-text: #bdbdbd;
-
-        color: var(--color-primary-text);
-        background-color: var(--color-primary);
-    }
 }


### PR DESCRIPTION
#15 

This pull request adds a theme toggle feature to the frontend, allowing users to switch between light and dark modes. It introduces a new `ThemeToggle` component, updates the navbar to include this toggle, and refactors CSS to support both themes using a `data-theme` attribute on the HTML element.

**Theme toggle functionality:**

* Added new `ThemeToggle` React component, which manages theme state, persists user preference in `localStorage`, and updates the HTML `data-theme` attribute to switch between light and dark modes. The toggle button displays different icons for each theme. (`Frontend/src/components/themeToggle.tsx`)
* Integrated the `ThemeToggle` component into the navigation bar so users can easily switch themes from anywhere in the app. (`Frontend/src/components/navbar.tsx`) [[1]](diffhunk://#diff-38ddd363988e7db0fb9f0cec14b5968b9c045af45b64c16d43d9cdc6c5f071a0R5) [[2]](diffhunk://#diff-38ddd363988e7db0fb9f0cec14b5968b9c045af45b64c16d43d9cdc6c5f071a0R179-R180)

**Styling and CSS updates:**

* Refactored CSS to define separate color variables for light and dark themes using `html[data-theme="light"]` and `html[data-theme="dark"]`. This enables dynamic theme switching based on the `data-theme` attribute. (`Frontend/src/index.css`)
* Removed the old `:root` color scheme and the `@media (prefers-color-scheme: light)` block, centralizing theme management under the new system. (`Frontend/src/index.css`) [[1]](diffhunk://#diff-13c1ca96b9638e4d910e9e3f8207f4306ef7ef8206ec560285ce488db852d723L20-L22) [[2]](diffhunk://#diff-13c1ca96b9638e4d910e9e3f8207f4306ef7ef8206ec560285ce488db852d723L49-L61)

**Minor UI changes:**

* Removed redundant transition classes from the navbar for cleaner styling, as theme transitions are now handled by the toggle button. (`Frontend/src/components/navbar.tsx`)